### PR TITLE
xPendingReboot: fix for resource not detecting a pending reboot after domain join

### DIFF
--- a/DSCResources/MSFT_xPendingReboot/MSFT_xPendingReboot.psm1
+++ b/DSCResources/MSFT_xPendingReboot/MSFT_xPendingReboot.psm1
@@ -2,16 +2,18 @@
 {
     [CmdletBinding()]
     [OutputType([Hashtable])]
-     param
+    param
     (
-    [Parameter(Mandatory=$true)]
-    [string]$Name,
-    
-    [Parameter()]
-    [bool]$SkipCcmClientSDK
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [bool]
+        $SkipCcmClientSDK
     )
 
-    $ComponentBasedServicingKeys = (Get-ChildItem 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\').Name
+    $ComponentBasedServicingKeys = (Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\').Name
     if ($ComponentBasedServicingKeys)
     {
         $ComponentBasedServicing = $ComponentBasedServicingKeys.Split("\") -contains "RebootPending"
@@ -21,7 +23,7 @@
         $ComponentBasedServicing = $false
     }
 
-    $WindowsUpdateKeys = (Get-ChildItem 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\').Name
+    $WindowsUpdateKeys = (Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\').Name
     if ($WindowsUpdateKeys)
     {
         $WindowsUpdate = $WindowsUpdateKeys.Split("\") -contains "RebootRequired"
@@ -31,12 +33,12 @@
         $WindowsUpdate = $false
     }
 
-    $PendingFileRename = (Get-ItemProperty 'hklm:\SYSTEM\CurrentControlSet\Control\Session Manager\').PendingFileRenameOperations.Length -gt 0
-    $ActiveComputerName = (Get-ItemProperty 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName').ComputerName
-    $PendingComputerName = (Get-ItemProperty 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName').ComputerName
+    $PendingFileRename = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\').PendingFileRenameOperations.Length -gt 0
+    $ActiveComputerName = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName').ComputerName
+    $PendingComputerName = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName').ComputerName
     $PendingComputerRename = $ActiveComputerName -ne $PendingComputerName
 
-    
+
 
     if (-not $SkipCcmClientSDK)
     {
@@ -46,8 +48,9 @@
             Name='DetermineIfRebootPending'
             ErrorAction='Stop'
         }
-        
-        Try {
+
+        Try
+        {
             $CCMClientSDK = Invoke-WmiMethod @CCMSplat
         }
         Catch
@@ -71,15 +74,31 @@
 Function Set-TargetResource
 {
     [CmdletBinding()]
-     param
+    param
     (
-    [Parameter(Mandatory=$true)]
-    [string]$Name,
-    [bool]$SkipComponentBasedServicing,
-    [bool]$SkipWindowsUpdate,
-    [bool]$SkipPendingFileRename,
-    [bool]$SkipPendingComputerRename,
-    [bool]$SkipCcmClientSDK
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [bool]
+        $SkipComponentBasedServicing,
+
+        [Parameter()]
+        [bool]
+        $SkipWindowsUpdate,
+
+        [Parameter()]
+        [bool]
+        $SkipPendingFileRename,
+
+        [Parameter()]
+        [bool]
+        $SkipPendingComputerRename,
+
+        [Parameter()]
+        [bool]
+        $SkipCcmClientSDK
     )
 
     $global:DSCMachineStatus = 1
@@ -89,15 +108,31 @@ Function Test-TargetResource
 {
     [CmdletBinding()]
     [OutputType([Boolean])]
-     param
+    param
     (
-    [Parameter(Mandatory=$true)]
-    [string]$Name,
-    [bool]$SkipComponentBasedServicing,
-    [bool]$SkipWindowsUpdate,
-    [bool]$SkipPendingFileRename,
-    [bool]$SkipPendingComputerRename,
-    [bool]$SkipCcmClientSDK
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [bool]
+        $SkipComponentBasedServicing,
+
+        [Parameter()]
+        [bool]
+        $SkipWindowsUpdate,
+
+        [Parameter()]
+        [bool]
+        $SkipPendingFileRename,
+
+        [Parameter()]
+        [bool]
+        $SkipPendingComputerRename,
+
+        [Parameter()]
+        [bool]
+        $SkipCcmClientSDK
     )
 
     $status = Get-TargetResource $Name -SkipCcmClientSDK $SkipCcmClientSDK

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Details are returned by Get-DSCConfiguration.
 ## Versions
 
 ### Unreleased
+* Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 
 ### 0.3.0.0
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Details for all read-only properties are returned by Get-DscConfiguration
 
 ### Unreleased
 
+### 0.4.0.0
+
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * Fixes registry not being evaluated correctly.
 * Fixes failing tests introduced in changes to Pester 4.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/25n3uaum4x6cv4dg/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xpendingreboot/branch/master)
-
 # xPendingReboot
 
-The **xPendingReboot** contains the **xPendingReboot** DSC resource. 
+[![Build status](https://ci.appveyor.com/api/projects/status/25n3uaum4x6cv4dg/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xpendingreboot/branch/master)
+
+The **xPendingReboot** contains the **xPendingReboot** DSC resource.
 xPendingReboot examines three specific registry locations where a Windows Server might indicate that a reboot is pending and allows DSC to predictably handle the condition.
 
 Note: The expectation is that this resource will be used in conjunction with knowledge of DSC Local Configuration Manager, which has the ability to manage whether reboots happen automatically using the RebootIfNeeded parameter.
@@ -12,13 +12,13 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Contributing
-Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
+Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResources/blob/master/CONTRIBUTING.md).
 
 ## Description
 
 The **xPendingReboot** module containes the **xPendingReboot** resource, which examines three specific registry locations where a Windows Server might indicate that a reboot is pending, and allows DSC to predictably handle the condition.
-DSC determines how to handle pending reboot conditions using the Local Configuration Management (LCM) setting RebootNodeIfNeeded. 
+DSC determines how to handle pending reboot conditions using the Local Configuration Management (LCM) setting RebootNodeIfNeeded.
 When DSC resources require reboot, within a Set statement in a DSC Resource the global variable DSCMachineStatus is set to value '1'.
 When this condition occurs and RebootNodeIfNeeded is set to 'True', DSC reboots the machine after a successful Set.
 Otherwise, the reboot is postponed.
@@ -31,7 +31,6 @@ Details for all read-only properties are returned by Get-DscConfiguration
 
 * **Name**: Required parameter that must be unique per instance of the resource within a configuration.
 * **ComponentBasedServicing**: (Read-only) One of the locations that are examined by the resource.
-Details are returned by Get-DSCConfiguration.
 * **SkipComponentBasedServicing**: (Write) Skip reboots triggered by the Component-Based Servicing component.
 * **WindowsUpdate**: (Read-only) One of the locations that are examined by the resource.
 * **SkipWindowsUpdate**: (Write) Skip reboots triggered by Windows Update.
@@ -44,7 +43,11 @@ Details are returned by Get-DSCConfiguration.
 ## Versions
 
 ### Unreleased
+
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Fixes registry not being evaluated correctly.
+* Fixes failing tests introduced in changes to Pester 4.
+* Change layout of parameters to compile with style guide.
 
 ### 0.3.0.0
 
@@ -53,13 +56,12 @@ Details are returned by Get-DSCConfiguration.
 
 ### 0.2.0.0
 
-* Added parameters which allow you to skip reboots triggered by the individual components. For example, you can choose not to
-	reboot if Windows Update requested a reboot.
+* Added parameters which allow you to skip reboots triggered by the individual components. For example, you can choose not to reboot if Windows Update requested a reboot.
 
 ### 0.1.0.2
 
 * Documentation changes:
-    - Added information on PendingComputerRename and CcmClientSdk.
+  * Added information on PendingComputerRename and CcmClientSdk.
 
 ### 0.1.0.1
 
@@ -67,9 +69,8 @@ Details are returned by Get-DSCConfiguration.
 
 ### 0.1.0.0
 
-* Initial release with the following resources 
-    * xPendingReboot
-
+* Initial release with the following resources
+  * xPendingReboot
 
 ## Examples
 
@@ -78,40 +79,40 @@ Details are returned by Get-DSCConfiguration.
 This configuration leverages xPendingReboot and sets the LCM setting to allow automatic reboots.
 
 ```powershell
-Configuration CheckForPendingReboot 
-{        
-    Node 'NodeName' 
-    {  
+Configuration CheckForPendingReboot
+{
+    Node 'NodeName'
+    {
         xPendingReboot Reboot1
-        { 
+        {
             Name = 'BeforeSoftwareInstall'
         }
         LocalConfigurationManager
         {
             RebootNodeIfNeeded = $True
-        } 
-    }  
-} 
+        }
+    }
+}
 ```
 
 ### Identify if reboots are pending but do not automatically reboot (managed by DSC)
 
-This configuration will install the hotfix from a URI that is connected to a particular hotfix ID. 
+This configuration will install the hotfix from a URI that is connected to a particular hotfix ID.
 It then leverages xPendingReboot and configures the LCM to allow automatic reboots.
 
 ```powershell
-Configuration CheckForPendingReboot 
-{        
-    Node 'NodeName' 
-    {  
+Configuration CheckForPendingReboot
+{
+    Node 'NodeName'
+    {
         xPendingReboot Reboot1
-        { 
+        {
             Name = 'BeforeSoftwareInstall'
         }
         LocalConfigurationManager
         {
             RebootNodeIfNeeded = 'False'
-        } 
-    }  
-} 
+        }
+    }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ xPendingReboot examines three specific registry locations where a Windows Server
 Note: The expectation is that this resource will be used in conjunction with knowledge of DSC Local Configuration Manager, which has the ability to manage whether reboots happen automatically using the RebootIfNeeded parameter.
 For more information on configuring the LCM, please reference [this TechNet article](https://technet.microsoft.com/en-us/library/dn249922.aspx).
 
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
 ## Contributing
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 

--- a/Tests/xPendingReboot.tests.ps1
+++ b/Tests/xPendingReboot.tests.ps1
@@ -1,7 +1,7 @@
-<# 
+<#
 .summary
     Test suite for MSFT_xPendingReboot.psm1
-    For PR https://github.com/PowerShell/xPendingReboot/pull/1 
+    For PR https://github.com/PowerShell/xPendingReboot/pull/1
 #>
 [CmdletBinding()]
 param()
@@ -17,26 +17,26 @@ Describe 'Get-TargetResource' {
         # Used by ComponentBasedServicing
         Mock Get-ChildItem {
             return @{ Name = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending' }
-        } -ParameterFilter { $Path -eq 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         # Used by WindowsUpdate
         Mock Get-ChildItem {
-            return @{ Name = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' } 
-        } -ParameterFilter { $Path -eq 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+            return @{ Name = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired' }
+        } -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         # Used by PendingFileRename
         Mock Get-ItemProperty {
             return @{ PendingFileRenameOperations= @("File1", "File2") }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\Session Manager\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
          # Used by PendingComputerRename
         Mock Get-ItemProperty {
             return @{ ComputerName = "box2" }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         Mock Get-ItemProperty {
             return @{ ComputerName = "box" }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         Mock Invoke-WmiMethod {
             return New-Object PSObject -Property @{
@@ -48,51 +48,51 @@ Describe 'Get-TargetResource' {
 
         $value = Get-TargetResource -Name "Test"
         It "All mocks were called" {
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
-        
+
         It "Component Based Servicing should be true" {
-            $value.ComponentBasedServicing | Should Be $true
+            $value.ComponentBasedServicing | Should -Be $true
         }
 
         It "WindowsUpdate should be true" {
-            $value.ComponentBasedServicing | Should Be $true
+            $value.ComponentBasedServicing | Should -Be $true
         }
         It "Pending File Rename should be true" {
-            $value.PendingFileRename | Should Be $true
+            $value.PendingFileRename | Should -Be $true
         }
         It "Pending Computer Rename should be true" {
-            $value.PendingComputerRename | Should Be $true
+            $value.PendingComputerRename | Should -Be $true
         }
         It "Ccm Client SDK should be true" {
-            $value.CcmClientSDK | Should Be $true
+            $value.CcmClientSDK | Should -Be $true
         }
     }
-    
+
     Context "No Reboots Are Required" {
         # Used by ComponentBasedServicing
         Mock Get-ChildItem {
             <# return nothing to catch issue #4 #>
-        } -ParameterFilter { $Path -eq 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         # Used by WindowsUpdate
         Mock Get-ChildItem {
             <# return nothing to catch issue #4 #>
-        } -ParameterFilter { $Path -eq 'hklm:SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         # Used by PendingFileRename
         Mock Get-ItemProperty {
             return @{ PendingFileRenameOperations= @() }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\Session Manager\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
          # Used by PendingComputerRename
         Mock Get-ItemProperty {
             return @{  }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         Mock Get-ItemProperty {
             return @{  }
-        } -ParameterFilter { $Path -eq 'hklm:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
+        } -ParameterFilter { $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName' }  -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         Mock Invoke-WmiMethod {
             return New-Object PSObject -Property @{
@@ -103,43 +103,43 @@ Describe 'Get-TargetResource' {
         } -ModuleName "MSFT_xPendingReboot" -Verifiable
 
         $value = Get-TargetResource -Name "Test"
-        
+
         It "Component Based Servicing should be false" {
-            $value.ComponentBasedServicing | Should Be $false
+            $value.ComponentBasedServicing | Should -Be $false
         }
 
         It "WindowsUpdate should be false" {
-            $value.ComponentBasedServicing | Should Be $false
+            $value.ComponentBasedServicing | Should -Be $false
         }
         It "Pending File Rename should be false" {
-            $value.PendingFileRename | Should Be $false
+            $value.PendingFileRename | Should -Be $false
         }
         It "Pending Computer Rename should be false" {
-            $value.PendingComputerRename | Should Be $false
+            $value.PendingComputerRename | Should -Be $false
         }
         It "Ccm Client SDK should be false" {
-            $value.CcmClientSDK | Should Be $false
+            $value.CcmClientSDK | Should -Be $false
         }
     }
-    
+
     Context "SkipCcmClientSdk" {
-        
+
         It "Calls 'Invoke-WmiMethod' when 'SkipCcmClientSdk' is not specified" {
             Mock Invoke-WmiMethod { } -ModuleName "MSFT_xPendingReboot"
-            
+
             $value = Get-TargetResource -Name "Test" -SkipCcmClientSdk $false
-            
+
             Assert-MockCalled Invoke-WmiMethod -Scope It -ModuleName "MSFT_xPendingReboot"
         }
-        
+
         It "Does not call 'Invoke-WmiMethod' when 'SkipCcmClientSdk' is specified" {
             Mock Invoke-WmiMethod { } -ModuleName "MSFT_xPendingReboot"
-            
+
             $value = Get-TargetResource -Name "Test" -SkipCcmClientSdk $true
-            
+
             Assert-MockCalled Invoke-WmiMethod -Scope It -Exactly 0 -ModuleName "MSFT_xPendingReboot"
         }
-         
+
     }
 }
 
@@ -160,13 +160,13 @@ Describe 'Test-TargetResource' {
         It "All Reboots are Skipped" {
             $result = Test-TargetResource -Name "Test" -SkipComponentBasedServicing $true -SkipWindowsUpdate $true -SkipPendingFileRename $true -SkipPendingComputerRename $true -SkipCcmClientSDK $true
 
-            $result | Should Be $true
+            $result | Should -Be $true
         }
 
         It "No Reboots are Skipped" {
             $result = Test-TargetResource -Name "Test" -SkipComponentBasedServicing $false -SkipWindowsUpdate $false -SkipPendingFileRename $false -SkipPendingComputerRename $false -SkipCcmClientSDK $false
 
-            $result | Should Be $false
+            $result | Should -Be $false
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,11 @@
 #---------------------------------# 
 version: 0.3.{build}.0
 install: 
-  - cinst -y pester
-  - git clone https://github.com/PowerShell/DscResource.Tests
-  - ps: Push-Location
-  - cd DscResource.Tests
-  - ps: Import-Module .\TestHelper.psm1 -force
-  - ps: Pop-Location
+    - git clone https://github.com/PowerShell/DscResource.Tests
+    - ps: |
+        Import-Module -Name .\DscResource.Tests\TestHelper.psm1 -Force
+        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+        Install-Module -Name Pester -Repository PSGallery -Force
 
 #---------------------------------# 
 #      build configuration        # 

--- a/xPendingReboot.psd1
+++ b/xPendingReboot.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '0.3.0.0'
+moduleVersion = '0.4.0.0'
 
 # ID used to uniquely identify this module
 GUID = '21430f59-750c-4c3c-bb93-4633b5b784c8'
@@ -47,11 +47,17 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = '* Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Fixes registry not being evaluated correctly.
+* Fixes failing tests introduced in changes to Pester 4.
+* Change layout of parameters to compile with style guide.
+
+'
 
     } # End of PSData hashtable
 
 } # End of PrivateData hashtable
 }
+
 
 


### PR DESCRIPTION
xPendingReboot resource was not detecting a pending reboot after domain join

used code from https://gallery.technet.microsoft.com/scriptcenter/Get-PendingReboot to correct this behavior

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpendingreboot/10)

<!-- Reviewable:end -->
