### PR TITLE
Deprecate Resource - Migrated to ComputerManagementDsc - Fixes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# **THIS MODULE HAS BEEN DEPRECATED**
+
+It will no longer be released.
+Please use the 'PendingReboot' resource in [ComputerManagementDsc](https://github.com/PowerShell/ComputerManagementDsc)
+instead.
+
 # xPendingReboot
 
 [![Build status](https://ci.appveyor.com/api/projects/status/25n3uaum4x6cv4dg/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xpendingreboot/branch/master)
@@ -44,6 +50,8 @@ Details for all read-only properties are returned by Get-DscConfiguration
 
 ### Unreleased
 
+* THIS MODULE HAS BEEN DEPRECATED. It will no longer be released.
+  Please use the 'PendingReboot' resource in ComputerManagementDsc instead.
 * Update appveyor.yml to use the default template.
 * Added default template files .codecov.yml, .gitattributes, and .gitignore, and
   .vscode folder.
@@ -86,7 +94,7 @@ Details for all read-only properties are returned by Get-DscConfiguration
 This configuration leverages xPendingReboot and sets the LCM setting to allow automatic reboots.
 
 ```powershell
-Configuration CheckForPendingReboot 
+Configuration CheckForPendingReboot
 {
     Node 'NodeName'
     {
@@ -107,7 +115,7 @@ Configuration CheckForPendingReboot
 This configuration leverages xPendingReboot and sets the LCM setting to disallow automatic reboots.
 
 ```powershell
-Configuration CheckForPendingReboot 
+Configuration CheckForPendingReboot
 {
     Node 'NodeName'
     {


### PR DESCRIPTION
### Pull Request (PR) description

This PR deprecates the resource as it has been migrated to ComputerManagementDsc.

Can you also set the GitHub repository description to:
**THIS MODULE HAS BEEN DEPRECATED Please use PendingReboot in ComputerManagementDsc instead: https://github.com/PowerShell/ComputerManagementDsc**

#### This Pull Request (PR) fixes the following issues

Fixes #27

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@gaelcolas - can you merge this after CompterManagementDsc has been released?

I've raised this issue https://github.com/PowerShell/DscResources/issues/529 to track updating the documentation on docs.microsoft.com once we've released ComputerManagementDsc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpendingreboot/28)
<!-- Reviewable:end -->
